### PR TITLE
GC-71887 Deprecate grabcad-graphql-shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<p align="center" style="font-weight: bold; font-size: 5em; color: red; margin-bottom: 0;">DEPRECATED</p>
-<p align="center" style="font-weight: bold; font-size: 3em">Use <a href="https://github.com/maticzav/graphql-shield">graphql-shield</a> instead</p>
-<hr />
+# DEPRECATED - USE [graphql-shield](https://github.com/maticzav/graphql-shield) INSTEAD
 
 <p align="center"><img src="https://imgur.com/DX1VKtn.png" width="150" /></p>
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center" style="font-weight: bold; font-size: 5em; color: red; margin-bottom: 0;">DEPRECATED</p>
+<p align="center" style="font-weight: bold; font-size: 3em">Use <a href="https://github.com/maticzav/graphql-shield">graphql-shield</a> instead</p>
+<hr />
+
 <p align="center"><img src="https://imgur.com/DX1VKtn.png" width="150" /></p>
 
 # graphql-shield


### PR DESCRIPTION
This repo will be deprecated after https://github.com/GrabCAD/company-server/pull/356 is merged.

[Machine's procedure for deprecating repos](https://stratasys-inc.slack.com/archives/C14TCB84Q/p1626106375100000?thread_ts=1626097255.098700&cid=C14TCB84Q)